### PR TITLE
Update Loots on Short  Grass

### DIFF
--- a/neo/src/main/java/com/unrealdinnerbone/jags/data/LootModifierGenerator.java
+++ b/neo/src/main/java/com/unrealdinnerbone/jags/data/LootModifierGenerator.java
@@ -24,7 +24,7 @@ public class LootModifierGenerator extends GlobalLootModifierProvider {
     @Override
     protected void start() {
         add("grass_seed", new AddItemModifier(
-                createChanceCondition(0.1f, RLUtils.rl("minecraft", "blocks/grass")), new ItemStack(JAGSRegistry.GRASS_SEED.get())));
+                createChanceCondition(0.1f, RLUtils.rl("minecraft", "blocks/short_grass")), new ItemStack(JAGSRegistry.GRASS_SEED.get())));
     }
 
     public static LootItemCondition[] createChanceCondition(float chance, ResourceLocation table) {


### PR DESCRIPTION
from grass to short_grass was renamed in 1.20.3 https://minecraft.wiki/w/Short_Grass#History  deploy to  the right  bran